### PR TITLE
Fix less grammar scope

### DIFF
--- a/grammars/vue.cson
+++ b/grammars/vue.cson
@@ -200,7 +200,7 @@ patterns: [
       "3":
         name: "punctuation.definition.tag.html"
     end: "(</)((?i:style))(>)(?:\\s*\\n)?"
-    name: "source.less.embedded.html"
+    name: "source.css.less.embedded.html"
     patterns: [
       {
         include: "#tag-stuff"
@@ -213,7 +213,7 @@ patterns: [
         end: "(?=</(?i:style))"
         patterns: [
           {
-            include: "source.less"
+            include: "source.css.less"
           }
         ]
       }


### PR DESCRIPTION
This enables missing Less syntax highlighting in Vue component files.

The scope name for Less in Atom is for some reason `source.css.less` (source: https://github.com/atom/language-less/blob/master/grammars/less.cson#L2)
