### PR TITLE
Support custom kebab-case html tags fully

### DIFF
--- a/grammars/vue.cson
+++ b/grammars/vue.cson
@@ -381,7 +381,7 @@ patterns: [
     ]
   }
   {
-    begin: "(</?)((?i:address|blockquote|dd|div|dl|dt|fieldset|form|frame|frameset|h1|h2|h3|h4|h5|h6|iframe|noframes|object|ol|p|ul|applet|center|dir|hr|menu|pre)\\b)"
+    begin: "(</?)((?i:address|blockquote|dd|div|dl|dt|fieldset|form|frame|frameset|h1|h2|h3|h4|h5|h6|iframe|noframes|object|ol|p|ul|applet|center|dir|hr|menu|pre)\\b)(?!-)"
     beginCaptures:
       "1":
         name: "punctuation.definition.tag.begin.html"
@@ -399,7 +399,7 @@ patterns: [
     ]
   }
   {
-    begin: "(</?)((?i:a|abbr|acronym|area|b|base|basefont|bdo|big|br|button|caption|cite|code|col|colgroup|del|dfn|em|font|head|html|i|img|input|ins|isindex|kbd|label|legend|li|link|map|meta|noscript|optgroup|option|param|q|s|samp|script|select|small|span|strike|strong|style|sub|sup|table|tbody|td|textarea|tfoot|th|thead|title|tr|tt|u|var)\\b)"
+    begin: "(</?)((?i:a|abbr|acronym|area|b|base|basefont|bdo|big|br|button|caption|cite|code|col|colgroup|del|dfn|em|font|head|html|i|img|input|ins|isindex|kbd|label|legend|li|link|map|meta|noscript|optgroup|option|param|q|s|samp|script|select|small|span|strike|strong|style|sub|sup|table|tbody|td|textarea|tfoot|th|thead|title|tr|tt|u|var)\\b)(?!-)"
     beginCaptures:
       "1":
         name: "punctuation.definition.tag.begin.html"


### PR DESCRIPTION
Fix the syntax highlight of custom tags which start with reserved keywords, such as `base`.
