### PR TITLE
Suggestion for template: using Standard.js syntaxes

### DIFF
--- a/snippets/vue.cson
+++ b/snippets/vue.cson
@@ -8,16 +8,15 @@
 
       <script>
       export default {
-        data() {
-          return {
-          };
+        data () {
+          return { }
         },
         computed: {},
-        ready() {},
-        attached() {},
+        ready () {},
+        attached () {},
         methods: {},
         components: {}
-      };
+      }
       </script>
 
       <style lang="${2:css}">


### PR DESCRIPTION
As the vuejs ecosystem (vue-cli) use the [standard js](https://github.com/feross/standard) linter, I suggest to fix the template snippet with a standard syntax.
