### PR TITLE
Update vue.cson

### DIFF
--- a/snippets/vue.cson
+++ b/snippets/vue.cson
@@ -12,8 +12,7 @@
           return {}
         },
         computed: {},
-        ready () {},
-        attached () {},
+        mounted () {},
         methods: {},
         components: {}
       }


### PR DESCRIPTION
Replace `ready()` ([deprecated](http://vuejs.org/guide/migration.html#ready-deprecated)) and `attached()` ([deprecated](http://vuejs.org/guide/migration.html#attached-deprecated)) with `mounted()`, in the snippet, for Vue 2.0

We could also add two snippets, supporting v1 & v2. I looked to add a setting for what version a user wants to default to, but didn't get far enough to see if you can use config variables in a snippet.
