### PR TITLE
Support snake_case in attributes

### DIFF
--- a/grammars/vue.cson
+++ b/grammars/vue.cson
@@ -658,7 +658,7 @@ repository:
     ]
   "vue-directive":
     name: "meta.directive.vue"
-    begin: "(?:\\b(v-)|(:|@))([a-zA-Z][0-9a-zA-Z\\-\\:\\.]+)\\s*(=)"
+    begin: "(?:\\b(v-)|(:|@))([a-zA-Z][0-9a-zA-Z\\-\\:\\._]+)\\s*(=)"
     end: "(?<='|\")"
     captures:
       "1":
@@ -769,7 +769,7 @@ repository:
     ]
   "tag-generic-attribute":
     name: "entity.other.attribute-name.html"
-    match: "\\b([a-zA-Z\\-:]+)"
+    match: "\\b([a-zA-Z\\-:_]+)"
   "tag-id-attribute":
     name: "meta.attribute-with-value.id.html"
     begin: "\\b(id)\\b\\s*(=)"


### PR DESCRIPTION
Hello! Some projects I work with use snake_case for their javascript code (for consistency with other languages used in the project). Vue attributes can happily be named in snake_case but unfortunately atom-language-vue wasn't highlighting directives and attributes with underscores nicely.

I edited my copy of vue.cson; adding "_" into the attribute and directive regexes has got that working for me. I've created this pull request in the hope that you think this is something everyone could benefit from :)

Cheers
David