### PR TITLE
Add auto indent settings working with eslint-plugin-vue for template blocks

### DIFF
--- a/settings/vue.cson
+++ b/settings/vue.cson
@@ -1,0 +1,6 @@
+'.text.html.vue':
+  'editor':
+    'autoIndentOnPaste': true
+    'softTabs': true
+    'increaseIndentPattern': '^\\s*((<.*[^>])|>)\\s*$'
+    'decreaseIndentPattern': '^\\s*>\\s*$'


### PR DESCRIPTION
I'm new to Vue. When I startup a new project by cloning the official `webpack` repo, the indentation suggestions from `eslint-plugin-vue` with `plugin:vue/recommended` rules doesn't quite match to the auto indent and it's annoying.

For example, eslint hint shows:
![screen shot 2018-02-15 at 8 35 38 am](https://user-images.githubusercontent.com/1802713/36235403-530fb070-122b-11e8-8064-2bbe8727cd14.png)

Add new lines by typing `enter`s will get this result:
![screen shot 2018-02-15 at 8 38 28 am](https://user-images.githubusercontent.com/1802713/36235453-bb77fad2-122b-11e8-832b-d32faafbe839.png)

As the suggested format, we want the code look like this:
![screen shot 2018-02-15 at 1 19 46 pm](https://user-images.githubusercontent.com/1802713/36241717-ecade32e-1252-11e8-8d68-9c7c4868d3a2.png)

So I added a setting file to the settings directory to make sure the indent will be auto increased after an open tag without the greater than sign in the presence like `<whatever`. And any line that is consists by only a single greater than sign `>` along with white space chars `\s` will auto decrease the indent. After those lines till the matching closing tags will be the inner content, so the indent should be increased as well since we had decreased the `>` sign. The result should looks like this:
![screen shot 2018-02-15 at 1 19 46 pm](https://user-images.githubusercontent.com/1802713/36242018-97952bc0-1254-11e8-9a46-b858b128bc83.png)

I hope someone could benefit from this.