### PR TITLE
Add HAML Highlighting

### DIFF
--- a/grammars/vue.cson
+++ b/grammars/vue.cson
@@ -377,6 +377,35 @@ patterns: [
     ]
   }
   {
+   name: "source.haml.embedded.html"
+   begin: "(?:^\\s+)?(<)((?i:template))\\b(?=[^>]*lang=[\"']haml[\"'])"
+   end: "(</)((?i:template))(>)(?:\\s*\\n)?"
+   captures:
+     "1":
+       name: "punctuation.definition.tag.html"
+     "2":
+       name: "entity.name.tag.style.html"
+     "3":
+       name: "punctuation.definition.tag.html"
+   patterns: [
+     {
+       include: "#tag-stuff"
+     }
+     {
+       begin: "(>)"
+       beginCaptures:
+         "1":
+           name: "punctuation.definition.tag.html"
+       end: "(?=</(?i:template))"
+       patterns: [
+         {
+           include: "source.haml"
+         }
+       ]
+     }
+   ]
+  }
+  {
     name: "text.slm.embedded.html"
     begin: "(?:^\\s+)?(<)((?i:template))\\b(?=[^>]*lang=[\"']slm[\"'])"
     end: "(</)((?i:template))(>)(?:\\s*\\n)?"

--- a/grammars/vue.cson
+++ b/grammars/vue.cson
@@ -399,7 +399,7 @@ patterns: [
        end: "(?=</(?i:template))"
        patterns: [
          {
-           include: "source.haml"
+           include: "text.haml"
          }
        ]
      }


### PR DESCRIPTION
This adds HAML highlighting to the Vue component template section.

```html
<template lang="haml">
  %p 
    {{ greeting }} world!
</template>
```