### PR TITLE
in meta.tag.other.html scope, group optional ‘/‘ with the end ‘>’

### DIFF
--- a/grammars/vue.cson
+++ b/grammars/vue.cson
@@ -646,7 +646,7 @@ patterns: [
         name: "punctuation.definition.tag.begin.html"
       "2":
         name: "entity.name.tag.other.html"
-    end: "(>)"
+    end: "(/?>)"
     endCaptures:
       "1":
         name: "punctuation.definition.tag.end.html"


### PR DESCRIPTION
This is supposed to a fix for part of #103, where the end bracket on self-closing components isn't being ligatured correctly. Here's a screenshot after this patch:

<img width="321" alt="Screen Shot 2020-02-04 at 4 18 22 PM" src="https://user-images.githubusercontent.com/10248067/73799197-1903b400-476a-11ea-9f30-2de452f846e1.png">

And before:

<img width="320" alt="Screen Shot 2020-02-04 at 4 20 22 PM" src="https://user-images.githubusercontent.com/10248067/73799248-46e8f880-476a-11ea-884f-251043ed3b58.png">
