### PR TITLE
Make `bracket-matcher` Happy

### DIFF
--- a/grammars/vue.cson
+++ b/grammars/vue.cson
@@ -532,11 +532,13 @@ patterns: [
   }
   {
     name: "source.js.embedded.html"
-    begin: "(?:^\\s+)?(<)((?i:script))\\b(?![^>]*/>|lang=[\"'].*[\"'])"
+    begin: "(?:^\\s+)?((<)((?i:script)))\\b(?![^>]*\/>|lang=[\"'].*[\"'])"
     beginCaptures:
       "1":
-        name: "punctuation.definition.tag.html"
+        name: "meta.tag.other.html"
       "2":
+        name: "punctuation.definition.tag.html"
+      "3":
         name: "entity.name.tag.script.html"
     end: "(?<=</(script|SCRIPT))(>)(?:\\s*\\n)?"
     endCaptures:
@@ -547,12 +549,14 @@ patterns: [
         include: "#tag-stuff"
       }
       {
-        begin: "(?<!</(?:script|SCRIPT))(>)"
-        end: "(</)((?i:script))"
+        begin: "(?<!<\/(?:script|SCRIPT))(>)"
+        end: "((<\/)((?i:script)))"
         captures:
           "1":
-            name: "punctuation.definition.tag.html"
+            name: "meta.tag.other.html"
           "2":
+            name: "punctuation.definition.tag.html"
+          "3":
             name: "entity.name.tag.script.html"
         patterns: [
           {

--- a/grammars/vue.cson
+++ b/grammars/vue.cson
@@ -288,15 +288,24 @@ patterns: [
   }
   {
     name: "source.css.embedded.html"
-    begin: "(?:^\\s+)?(<)((?i:style))\\b(?![^>]*/>|lang=[\"'].*[\"'])"
-    captures:
+    begin: "(?:^\\s+)?((<)((?i:style)))\\b(?![^>]*\/>|lang=[\"'].*[\"'])"
+    beginCaptures:
       "1":
-        name: "punctuation.definition.tag.html"
+        name: "meta.tag.other.html"
       "2":
-        name: "entity.name.tag.style.html"
-      "3":
         name: "punctuation.definition.tag.html"
-    end: "(</)((?i:style))(>)(?:\\s*\\n)?"
+      "3":
+        name: "entity.name.tag.style.html"
+    end: "((<\/)((?i:style))(>))(?:\\s*\\n)?"
+    endCaptures:
+      "1":
+        name: "meta.tag.other.html"
+      "2":
+        name: "punctuation.definition.tag.html"
+      "3":
+        name: "entity.name.tag.style.html"
+      "4":
+        name: "punctuation.definition.tag.html"
     patterns: [
       {
         include: "#tag-stuff"

--- a/spec/grammars-spec.js
+++ b/spec/grammars-spec.js
@@ -514,17 +514,17 @@ a
 
       expect(tokens[0]).toEqual({
         value: "<",
-        scopes: [ "text.html.vue", "source.js.embedded.html", "punctuation.definition.tag.html" ]
+        scopes: [ "text.html.vue", "source.js.embedded.html", "meta.tag.other.html", "punctuation.definition.tag.html" ]
       });
 
       expect(tokens[1]).toEqual({
         value: "script",
-        scopes: [ "text.html.vue", "source.js.embedded.html", "entity.name.tag.script.html" ]
+        scopes: [ "text.html.vue", "source.js.embedded.html", "meta.tag.other.html", "entity.name.tag.script.html" ]
       });
 
       expect(tokens[2]).toEqual({
         value: ">",
-        scopes: [ "text.html.vue", "source.js.embedded.html", "punctuation.definition.tag.html" ]
+        scopes: [ "text.html.vue", "source.js.embedded.html", "meta.tag.other.html" ]
       });
 
       expect(tokens[3]).toEqual({
@@ -559,12 +559,12 @@ a
 
       expect(tokens[9]).toEqual({
         value: "</",
-        scopes: [ "text.html.vue", "source.js.embedded.html", "punctuation.definition.tag.html" ]
+        scopes: [ "text.html.vue", "source.js.embedded.html", "meta.tag.other.html", "punctuation.definition.tag.html" ]
       });
 
       expect(tokens[10]).toEqual({
         value: "script",
-        scopes: [ "text.html.vue", "source.js.embedded.html", "entity.name.tag.script.html" ]
+        scopes: [ "text.html.vue", "source.js.embedded.html", "meta.tag.other.html", "entity.name.tag.script.html" ]
       });
 
       expect(tokens[11]).toEqual({


### PR DESCRIPTION
I've detailed much more on #117 what the exact issue is.

But essentially, there were scopes expected to be present on the text of `script` from `<script>` that was only applied to the `<` and `>` causing `bracket-matcher` to only highlight the text if the cursor was near those ending characters, rather than on the entire piece of text.

While I did talk with Pulsar maintainers if the best solution was to modify how `bracket-matcher` handles this, we came to the conclusion that it would make the most sense to instead fix the scopes being supplied by this grammar instead.

So this PR fixes the underlighting of both `script` and `style` by wrapping the full captures in the scope that was expected of `bracket-matcher` while leaving the internal captures alone, to keep syntax highlighting as expected.

## Before 

![image](https://github.com/hedefalk/atom-vue/assets/26921489/91f39ccf-bb08-4125-b7c3-c384eaab57b8)

## After

![image](https://github.com/hedefalk/atom-vue/assets/26921489/39964ca7-65eb-498c-be18-e9f66fdfd8ef)

---

Resolves #117 